### PR TITLE
Enhance district validation to check for length constraints

### DIFF
--- a/src/forms/AddressForm.tsx
+++ b/src/forms/AddressForm.tsx
@@ -12,7 +12,7 @@ import valid from "validator";
 
 const {MrAutocomplete, MrTextInput} = Inputs<AddressFormFields>();
 const validateDistrict = (value: string) => {
-    if (value.trim().length < 1) {
+    if (value.trim().length < 1 || value.trim().length > 2) {
         return false;
     }
 


### PR DESCRIPTION
District longer than 2 characters shall be considered a wrong input.